### PR TITLE
Added method to click coordinates.

### DIFF
--- a/appium-helpers.js
+++ b/appium-helpers.js
@@ -2,6 +2,9 @@
 
 // The buttons on the ad screen cannot be recognized by same appium methods
 // on iOS as on Android, Use this method instead.
+
+var WD_GLOB;
+
 var staticTextElement = function(staticText, timeOut, pollInterval) {
   if(process.env.APPIUM_PLATFORM == "ios"){
     return this
@@ -74,12 +77,29 @@ var logContexts = function(tagStr){
     });
 }
 
+var tapCoordLong = function(xCoord, yCoord){
+  var action = new WD_GLOB.TouchAction();
+  var thisAction = action.longPress({el: null, x: xCoord, y: yCoord})
+  return this
+    .performTouchAction(action);
+}
+
+var tapCoord = function(xCoord, yCoord){
+  var action = new WD_GLOB.TouchAction();
+  var thisAction = action.tap({el: null, x: xCoord, y: yCoord})
+  return this
+    .performTouchAction(thisAction);
+}
+
 exports.configureWd = function(wd) {
+  WD_GLOB = wd;
   wd.addPromiseChainMethod('staticTextElement', staticTextElement);
   wd.addPromiseChainMethod('iosWaitElement', iosWaitElement);
   wd.addPromiseChainMethod('messagesFromLog', messagesFromLog);
   wd.addPromiseChainMethod('jsonObjectsFromLog', jsonObjectsFromLog);
   wd.addPromiseChainMethod('logContexts', logContexts);
+  wd.addPromiseChainMethod('tapCoordLong', tapCoordLong);
+  wd.addPromiseChainMethod('tapCoord', tapCoord);
 };
 
 exports.configureYiewdDriver = function(driver){


### PR DESCRIPTION
Usage: driver.tapCoord(x-coordinate, y-coordinate)

Storing wd globally for this feature. Global vars are not great, but I think we might need it later anyway.
