### PR TITLE
Made get_full_path safer

### DIFF
--- a/test_start_helpers.sh
+++ b/test_start_helpers.sh
@@ -49,7 +49,14 @@ function pull_screenshot_batch {
 }
 
 function get_full_path {
-  echo "$( cd "$(dirname "$1")"; echo "$(pwd)/$(basename "$1")" )"
+  if [ -f "$1" ]; then
+    echo "$( cd "$(dirname "$1")"; echo "$(pwd)/$(basename "$1")" )"
+  elif [ -d "$1" ]; then
+    echo "$(cd "$1"; echo "$(pwd)")"
+  else
+    echo "WARNING! get_full_path: no such file or dir! '$1'" 1>&2
+    echo "itest_niacin-get_full_path-failed.File-does-not-exist/$1"
+  fi
 }
 
 function android_reboot_and_wait_for_device_ready {


### PR DESCRIPTION
Running get_full_path for a non-existant file or folder caused it to basically return "$(pwd)/$(basename $1)" which proved confusing to debug. Changed it so it returns a clearly broken path and writes warning to std_err.

Not sure if we should should exit if argument is non-existant or just output the warning. I selected this method to avoid breaking any existing usage.
