### PR TITLE
Xcode8 appium16 changes

### DIFF
--- a/appium_helpers.py
+++ b/appium_helpers.py
@@ -63,6 +63,28 @@ def get_capabilities_15(options=None):
     }
 
 
+def get_capabilities_16(options=None):
+    """
+    Xcode8+, ios10+ only supports
+        'automationName' : 'XCUITest'
+    which is only supported in Appium1.6
+    """
+    if not options:
+        options = {}
+
+    return {
+        "automationName": "XCUITest",
+        "platformName": options.get("platformName"),
+        "browserName": None or options.get("browserName"),
+        "deviceName": options.get("deviceName"),
+        "app": options.get("app"),
+        "bundleId": options.get("bundleId"),
+        "udid": options.get("udid"),
+        "screenshotWaitTimeout": options.get("screenshotWaitTimeout", 3),
+        "defaultCommandTimeout": options.get("defaultCommandCommandTimeout", 500),
+    }
+
+
 def get_driver(driver=webdriver, addr='http://localhost:4723/wd/hub', capabilities=None):
     """
     Get the Appium Driver
@@ -175,6 +197,14 @@ class iOS(PlatformBase):
                            wait_time)
 
     @staticmethod
+    def find_and_wait_button_xpath(driver, xpath, wait_time=5):
+        return iOS.wait_by(driver,
+                           EC.presence_of_element_located,
+                           By.XPATH,
+                           xpath,
+                           wait_time=5)
+
+    @staticmethod
     def find_all_webview_elements_by_xpath(driver):
         return driver.find_elements_by_xpath('//UIAApplication[1]/UIAWindow[1]/UIAScrollView[1]/UIAWebView[1]/*')
 
@@ -249,6 +279,17 @@ class iOS(PlatformBase):
             print("Error taking screenshot {} in {} with error {}".format(name, dir, err.output))
             return False
         return True
+
+    @staticmethod
+    def get_device_name():
+        """
+        Get attached device name
+        """
+        try:
+            return check_output(["idevicename"]).decode("utf-8").strip('\n')
+        except CalledProcessError as err:
+            print("Error getting device-name with error {}".format(err.output))
+        return False
 
     @staticmethod
     def install_package(package_path, udid=None):

--- a/appium_helpers.py
+++ b/appium_helpers.py
@@ -193,6 +193,14 @@ class PlatformBase(object):
     def find_element_by_xpath(driver, xpath):
         return driver.find_element_by_xpath(xpath)
 
+    @staticmethod
+    def toggle_orientation(driver):
+        current_orientation = driver.orientation
+        if current_orientation == "PORTRAIT":
+            driver.orientation = "LANDSCAPE"
+        else:
+            driver.orientation = "PORTRAIT"
+
 
 #### Android Keywords #####
 class Android(PlatformBase):
@@ -237,7 +245,6 @@ class iOS(PlatformBase):
                            s,
                            wait_time)
 
-
     @staticmethod
     def find_all_webview_elements_by_xpath(driver):
         return driver.find_elements_by_xpath('//UIAApplication[1]/UIAWindow[1]/UIAScrollView[1]/UIAWebView[1]/*')
@@ -257,14 +264,6 @@ class iOS(PlatformBase):
     @staticmethod
     def find_all_window_elements(driver):
         return driver.find_elements_by_ios_uiautomation('.elements()')
-
-    @staticmethod
-    def toggle_orientation(driver):
-        current_orientation = driver.orientation
-        if current_orientation == "PORTRAIT":
-            driver.orientation = "LANDSCAPE"
-        else:
-            driver.orientation = "PORTRAIT"
 
     @staticmethod
     def get_xml_tree(driver):

--- a/appium_helpers.py
+++ b/appium_helpers.py
@@ -203,6 +203,9 @@ class Android(PlatformBase):
 class iOS(PlatformBase):
     def __init__(self, ios_driver='ui_automation', **options):
         super(iOS, self).__init__()
+        # @TODO: we need to divide the iOS class to 2 parts
+        #        one for the old <xcode8 <ios10 i.e. ui_automation and
+        #        the other for the new xcuitest for +xcode7 +ios10
         self.ios_driver = ios_driver
         print("IOS using the following ios strategy {}".format(self.ios_driver))
 

--- a/appium_helpers.py
+++ b/appium_helpers.py
@@ -161,13 +161,51 @@ class PlatformBase(object):
             print("Will try to tap the element location w:{}, h:{}".format(w, h))
             return driver.tap([(w, h)])
 
+    @staticmethod
+    def find_all_elements_by_xpath(driver):
+        return driver.find_elements_by_xpath('//*[not(*)]')
+
+    @staticmethod
+    def find_and_wait_button_xpath(driver, xpath, wait_time=5):
+        return PlatformBase.wait_by(driver,
+                                    EC.presence_of_element_located,
+                                    By.XPATH,
+                                    xpath,
+                                    wait_time=5)
+
+    @staticmethod
+    def wait_by(driver, expected_condition, by_method, element_identifier, wait_time=5):
+        """
+        See: http://selenium-python.readthedocs.io/waits.html
+        Args:
+            driver: instance of Appium.webdriver
+            expected_condition: what we condition we expect to happen
+            by_method: by with what Appium.webdriver.method we try to find the element
+            element_identifier: depending on 'by_method' what indentifier we try
+            to use to locate the elem
+            wait_time: time to wait element to appear
+
+        Returns: instance of appium.webdriver.webelement or TimeoutException
+        """
+        return WebDriverWait(driver, wait_time).until(expected_condition((by_method, element_identifier)))
+
+    @staticmethod
+    def find_element_by_xpath(driver, xpath):
+        return driver.find_element_by_xpath(xpath)
+
 
 #### Android Keywords #####
 class Android(PlatformBase):
     pass
 
+
 #### iOS Keywords #####
 class iOS(PlatformBase):
+    def __init__(self, ios_driver='ui_automation', **options):
+        super(iOS, self).__init__()
+        self.ios_driver = ios_driver
+        print("IOS using the following ios strategy {}".format(self.ios_driver))
+
     @staticmethod
     def find_buttons(driver, name):
         s = '.elements()["{}"]'.format(name)
@@ -196,21 +234,10 @@ class iOS(PlatformBase):
                            s,
                            wait_time)
 
-    @staticmethod
-    def find_and_wait_button_xpath(driver, xpath, wait_time=5):
-        return iOS.wait_by(driver,
-                           EC.presence_of_element_located,
-                           By.XPATH,
-                           xpath,
-                           wait_time=5)
 
     @staticmethod
     def find_all_webview_elements_by_xpath(driver):
         return driver.find_elements_by_xpath('//UIAApplication[1]/UIAWindow[1]/UIAScrollView[1]/UIAWebView[1]/*')
-
-    @staticmethod
-    def find_element_by_xpath(driver, xpath):
-        return driver.find_element_by_xpath(xpath)
 
     @staticmethod
     def find_webview_elements_by_xpath(driver, xpath):
@@ -227,22 +254,6 @@ class iOS(PlatformBase):
     @staticmethod
     def find_all_window_elements(driver):
         return driver.find_elements_by_ios_uiautomation('.elements()')
-
-    @staticmethod
-    def wait_by(driver, expected_condition, by_method, element_identifier, wait_time=5):
-        """
-        See: http://selenium-python.readthedocs.io/waits.html
-        Args:
-            driver: instance of Appium.webdriver
-            expected_condition: what we condition we expect to happen
-            by_method: by with what Appium.webdriver.method we try to find the element
-            element_identifier: depending on 'by_method' what indentifier we try
-            to use to locate the elem
-            wait_time: time to wait element to appear
-
-        Returns: instance of appium.webdriver.webelement or TimeoutException
-        """
-        return WebDriverWait(driver, wait_time).until(expected_condition((by_method, element_identifier)))
 
     @staticmethod
     def toggle_orientation(driver):

--- a/utils.py
+++ b/utils.py
@@ -1,9 +1,13 @@
 # -*- coding: utf-8 -*-
 from inspect import stack
 from time import time
+import string
+import random
+
 
 def function_name():
     return stack()[1][3]
+
 
 def timing(f):
     """
@@ -19,3 +23,22 @@ def timing(f):
         print("'%s' function took %0.3f ms to execute" % (f.__name__, (time2-time1)*1000.0))
         return ret
     return wrap
+
+
+def object_creator(name):
+    """
+    Return new class stubb
+
+    Usage:
+        stub = object_creator(mystub)
+        stub.var = "some string"
+    """
+    return type(name.capitalize(), (object,), {})
+
+
+def id_generator(size=6, chars=string.ascii_uppercase + string.digits):
+    """
+    Return a random string
+    http://stackoverflow.com/questions/2257441/random-string-generation-with-upper-case-letters-and-digits-in-python/23728630#23728630
+    """
+    return ''.join(random.SystemRandom().choice(chars) for _ in range(size))

--- a/utils.py
+++ b/utils.py
@@ -42,3 +42,7 @@ def id_generator(size=6, chars=string.ascii_uppercase + string.digits):
     http://stackoverflow.com/questions/2257441/random-string-generation-with-upper-case-letters-and-digits-in-python/23728630#23728630
     """
     return ''.join(random.SystemRandom().choice(chars) for _ in range(size))
+
+class UnittestRunException(Exception):
+    def __init__(self, *args, **kwargs):
+        Exception.__init__(self, *args, **kwargs)


### PR DESCRIPTION
1. basic capabilities for +xcode8, +ios10 using the `xcuitest`
2. moved some of the general functionality from `iOS()`-class to the `PlatformBase`
3. new `iOS` functionality
4. added few utility functions

I tested `2.` but please verify @PavelHUnity that nothing breaks from your side.

Requires latest appium (1.6 which is in beta). Also need to compile manually all the supporting [libraries](https://github.com/shusso/idevice-libs). It still has few issues which are tracked [here](https://github.com/appium/appium/issues/6895)
