### PR TITLE
Helper changes

### DIFF
--- a/appium_helpers.py
+++ b/appium_helpers.py
@@ -179,7 +179,7 @@ class PlatformBase(object):
                                     EC.presence_of_element_located,
                                     By.NAME,
                                     name,
-                                    wait_time=5)
+                                    wait_time)
     @staticmethod
     def find_and_wait_button(driver, query, strategy, expectation=EC.presence_of_element_located, wait_time=5):
         """

--- a/appium_helpers.py
+++ b/appium_helpers.py
@@ -320,7 +320,7 @@ class iOS(PlatformBase):
             return check_output(["idevicename"]).decode("utf-8").strip('\n')
         except CalledProcessError as err:
             print("Error getting device-name with error {}".format(err.output))
-        return False
+            return False
 
     @staticmethod
     def uninstall_package(bundle_id, udid=None):
@@ -336,9 +336,10 @@ class iOS(PlatformBase):
         try:
             print("uninstalling {} from {}".format(bundle_id, udid))
             check_output(["ideviceinstaller", "-u", str(udid), "-U", str(bundle_id)])
-            return True
+
         except CalledProcessError as err:
             print("Error uninstalling app {}, msg: {}".format(bundle_id, err))
+            return False
 
     @staticmethod
     def install_package(package_path, udid=None):
@@ -350,15 +351,13 @@ class iOS(PlatformBase):
         if not exists(package_path):
             print("Package '{}' doesn't exist".format(package_path))
             return False
-
         try:
             print("installing package {} in {}".format(package_path, udid))
             check_output(["ideviceinstaller", "-u", str(udid), "-i", package_path])
-            return True
         except CalledProcessError as err:
-            print("Error installing package to {} the device {}, msg: {}".format(package_path,
-                                                                                 udid,
-                                                                                 err))
+            print("Error installing package to {} the device {}, msg: {}".format(package_path, udid, err))
+            return False
+        return True
 
 class NiacinWebDriver(WebDriver):
     def __init__(self, command_executor='http://127.0.0.1:4444/wd/hub', desired_capabilities=None, browser_profile=None, proxy=None, keep_alive=False):

--- a/appium_helpers.py
+++ b/appium_helpers.py
@@ -174,6 +174,24 @@ class PlatformBase(object):
                                     wait_time=5)
 
     @staticmethod
+    def find_and_wait_button_name(driver, name, wait_time=5):
+        return PlatformBase.wait_by(driver,
+                                    EC.presence_of_element_located,
+                                    By.NAME,
+                                    name,
+                                    wait_time=5)
+    @staticmethod
+    def find_and_wait_button(driver, query, strategy, expectation=EC.presence_of_element_located, wait_time=5):
+        """
+        Find and wait element per query and strategy
+        """
+        return PlatformBase.wait_by(driver,
+                                    expectation,
+                                    strategy,
+                                    query,
+                                    wait_time)
+
+    @staticmethod
     def wait_by(driver, expected_condition, by_method, element_identifier, wait_time=5):
         """
         See: http://selenium-python.readthedocs.io/waits.html
@@ -228,7 +246,7 @@ class iOS(PlatformBase):
         return driver.find_element_by_ios_uiautomation(s)
 
     @staticmethod
-    def find_and_wait_button(driver, name, wait_time=5):
+    def find_and_wait_button_ios(driver, name, wait_time=5):
         s = '.elements()["{}"]'.format(name)
         return iOS.wait_by(driver,
                            EC.presence_of_element_located,

--- a/appium_helpers.py
+++ b/appium_helpers.py
@@ -171,7 +171,7 @@ class PlatformBase(object):
                                     EC.presence_of_element_located,
                                     By.XPATH,
                                     xpath,
-                                    wait_time=5)
+                                    wait_time)
 
     @staticmethod
     def find_and_wait_button_name(driver, name, wait_time=5):

--- a/appium_helpers.py
+++ b/appium_helpers.py
@@ -323,6 +323,24 @@ class iOS(PlatformBase):
         return False
 
     @staticmethod
+    def uninstall_package(bundle_id, udid=None):
+        """
+        Uninstall app from the device using 'ideviceinstaller' with bundle-id
+        """
+        if not bundle_id:
+            print("missing bundle_id, cannot continue")
+            return False
+        if not udid:
+            udid = environ.get("IDEVICE_UDID") or iOS.get_udid()[-1]
+
+        try:
+            print("uninstalling {} from {}".format(bundle_id, udid))
+            check_output(["ideviceinstaller", "-u", str(udid), "-U", str(bundle_id)])
+            return True
+        except CalledProcessError as err:
+            print("Error uninstalling app {}, msg: {}".format(bundle_id, err))
+
+    @staticmethod
     def install_package(package_path, udid=None):
         """
         Install package to the device using 'ideviceinstaller'
@@ -334,6 +352,7 @@ class iOS(PlatformBase):
             return False
 
         try:
+            print("installing package {} in {}".format(package_path, udid))
             check_output(["ideviceinstaller", "-u", str(udid), "-i", package_path])
             return True
         except CalledProcessError as err:

--- a/utils.py
+++ b/utils.py
@@ -65,6 +65,8 @@ def catcher(*exceptions, msg=None):
         yield
     except exceptions as err:
         print("{}: '{}'".format(msg, err))
+        return False
+    return True
 
 
 class UnittestRunException(Exception):

--- a/utils.py
+++ b/utils.py
@@ -3,6 +3,8 @@ from inspect import stack
 from time import time
 import string
 import random
+from collections import defaultdict
+from contextlib import contextmanager
 
 
 def function_name():
@@ -42,6 +44,28 @@ def id_generator(size=6, chars=string.ascii_uppercase + string.digits):
     http://stackoverflow.com/questions/2257441/random-string-generation-with-upper-case-letters-and-digits-in-python/23728630#23728630
     """
     return ''.join(random.SystemRandom().choice(chars) for _ in range(size))
+
+
+@contextmanager
+def catcher(*exceptions, msg=None):
+    """
+    Context manager for catching exceptions and showing a msg
+    in case of an exception (msg can be omitted)
+
+    Usage:
+        def my_method():
+            with catcher(Exception, MyCustomException,..., msg="exception msg"):
+                method_that_might_raise_exception()
+                another_method_that_might_raise_MycustomException()
+                ..
+    """
+    if not msg: msg = "Exception raised"
+
+    try:
+        yield
+    except exceptions as err:
+        print("{}: '{}'".format(msg, err))
+
 
 class UnittestRunException(Exception):
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
**note** renamed the ios method`find_and_wait_button` to `find_and_wait_button_ios`. There is now `find_and_wait_button` in the `PlatformBase` class (as it should've been there in the beginning).

Other changes
- `find_and_wait_button_name` (Platform)
- `uninstall_package` (ios)
- fixed return values to be more logical
- `catcher` to handle Exceptions using the python `with`
